### PR TITLE
Add domain reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 An advanced TypeScript simulation that creates and evolves digital unicellular organisms using Bitcoin Ordinals. Each organism is uniquely seeded from Bitcoin block data, ensuring deterministic but unique traits tied to blockchain history.
 
+**See [`docs/`](docs/README.md) for detailed domain documentation and automation instructions.**
+
 ## 🚀 Quick Start
 
 ```bash
@@ -94,6 +96,7 @@ Complete PowerShell automation package in `/scripts`:
 - **`build_design.md`**: Complete domain-driven architecture (2,180 lines)
 - **`addin.md`**: Additional implementation guides and missing components
 - **`.cursorrules`**: Comprehensive project standards (390 lines)
+- **`docs/` directory**: Organized reference extracted from `build_design.md`
 - **API Integration**: Bitcoin Ordinals protocol documentation
 
 ## 🚦 Project Status

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Protozoa Documentation
+
+This `docs` directory organizes key design references derived from `build_design.md`.
+
+- [Overview](overview/README.md)
+- [Domain Specifications](domains/README.md)
+- [Automation Scripts](scripts/README.md)

--- a/docs/domains/README.md
+++ b/docs/domains/README.md
@@ -1,0 +1,14 @@
+# Domain Specifications
+
+This directory contains per‑domain design notes extracted from `build_design.md`.
+
+- [Rendering](rendering.md)
+- [Animation](animation.md)
+- [Effect](effect.md)
+- [Trait](trait.md)
+- [Physics](physics.md)
+- [Particle](particle.md)
+- [Formation](formation.md)
+- [Group](group.md)
+- [RNG](rng.md)
+- [Bitcoin](bitcoin.md)

--- a/docs/domains/animation.md
+++ b/docs/domains/animation.md
@@ -1,0 +1,15 @@
+# Animation Domain
+
+Controls frame-based animations for particles. Consolidates all animation logic into a singleton service.
+
+## Interface
+```ts
+export interface IAnimationService {
+  startAnimation(role: string, config: AnimationConfig): void;
+  updateAnimations(delta: number): void;
+  stopAll(): void;
+  dispose(): void;
+}
+```
+
+`startAnimation` begins an animation sequence for a group or role. `updateAnimations` advances all active animations each frame. `stopAll` cancels any running sequences. Logging occurs via `createServiceLogger` and `createPerformanceLogger`.

--- a/docs/domains/bitcoin.md
+++ b/docs/domains/bitcoin.md
@@ -1,0 +1,20 @@
+# Bitcoin Domain
+
+Fetches block information and ordinals content from external APIs with caching and retry logic.
+
+## Interface
+```ts
+export interface IBitcoinService {
+  fetchBlockInfo(blockNumber: number): Promise<BlockInfo>;
+  getCachedBlockInfo(blockNumber: number): BlockInfo | undefined;
+  dispose(): void;
+}
+```
+
+Example fetch using the dev API:
+```ts
+const url = `https://ordinals.com/r/blockinfo/${blockNumber}`;
+const data = await (await fetch(url)).json();
+```
+
+Cached results are stored in a map keyed by block number. `dispose` clears the cache to free memory.

--- a/docs/domains/effect.md
+++ b/docs/domains/effect.md
@@ -1,0 +1,14 @@
+# Effect Domain
+
+Manages visual effects such as nebula clouds or explosions. The service stores predefined effect presets and allows triggering them at runtime.
+
+## Interface
+```ts
+export interface IEffectService {
+  triggerEffect(name: string, options?: any): void;
+  registerEffectPreset(name: string, config: EffectConfig): void;
+  dispose(): void;
+}
+```
+
+Use `triggerEffect` to start an effect by name. Presets can be registered via `registerEffectPreset`. Errors are logged with `createErrorLogger` if a preset is missing.

--- a/docs/domains/formation.md
+++ b/docs/domains/formation.md
@@ -1,0 +1,14 @@
+# Formation Domain
+
+Defines geometric formations for particle positioning. Provides caching for computed layouts and supports transitions via a separate blending service.
+
+## Interface (excerpt)
+```ts
+export interface IFormationService {
+  getFormationPattern(patternId: string): FormationPattern | undefined;
+  applyFormation(patternId: string, particleIds: string[]): void;
+  dispose(): void;
+}
+```
+
+Formations may be loaded from `formation/data` files. `applyFormation` positions particles using injected services (e.g., PhysicsService) without importing them directly. Blending between formations can be delegated to `FormationBlendingService`.

--- a/docs/domains/group.md
+++ b/docs/domains/group.md
@@ -1,0 +1,15 @@
+# Group Domain
+
+Handles clustering of particles into named groups. Supports RNG injection for random assignments.
+
+## Interface
+```ts
+export interface IGroupService {
+  formGroup(particleIds: string[]): ParticleGroup;
+  getGroup(id: string): ParticleGroup | undefined;
+  dissolveGroup(id: string): void;
+  dispose(): void;
+}
+```
+
+Groups are stored in an internal map. `configure` can inject an `IRNGService` for generating unique identifiers or random assignments.

--- a/docs/domains/particle.md
+++ b/docs/domains/particle.md
@@ -1,0 +1,15 @@
+# Particle Domain
+
+Maintains the simulation's particle entities. Creation and updates rely on injected Physics and Rendering services.
+
+## Interface
+```ts
+export interface IParticleService {
+  createParticle(initialTraits?: object): Particle;
+  getParticleById(id: string): Particle | undefined;
+  updateParticles(delta: number): void;
+  dispose(): void;
+}
+```
+
+Particles are stored in a private map keyed by ID. `configureDependencies` injects `IPhysicsService` and `IRenderingService` so this domain remains decoupled. Trait assignment uses `TraitService` during creation.

--- a/docs/domains/physics.md
+++ b/docs/domains/physics.md
@@ -1,0 +1,14 @@
+# Physics Domain
+
+Provides vector math utilities and distribution algorithms for particle positioning.
+
+## Interface
+```ts
+export interface IPhysicsService {
+  calculateDistribution(count: number, radius: number): Vector3[];
+  applyGravity(position: Vector3, delta: number): Vector3;
+  dispose(): void;
+}
+```
+
+`calculateDistribution` returns random positions within a sphere. `applyGravity` updates a vector using a gravity constant. Logging records calculations for debugging.

--- a/docs/domains/rendering.md
+++ b/docs/domains/rendering.md
@@ -1,0 +1,29 @@
+# Rendering Domain
+
+Handles Three.js scene management and rendering. Follows the singleton pattern with dependency injection for Formation and Effect services.
+
+## Interface
+```ts
+export interface IRenderingService {
+  initialize(canvas: HTMLCanvasElement, deps?: { formation?: IFormationService; effect?: IEffectService }): void;
+  renderFrame(delta: number): void;
+  addObject(obj: Object3D): void;
+  removeObject(obj: Object3D): void;
+  applyFormation(patternId: string): void;
+  applyEffect(effectName: string, options?: any): void;
+  dispose(): void;
+}
+```
+
+## Example Usage
+```ts
+import { renderingService } from '@/domains/rendering/services/renderingService';
+
+renderingService.initialize(document.querySelector('canvas')!);
+requestAnimationFrame(function loop(now) {
+  renderingService.renderFrame(now);
+  requestAnimationFrame(loop);
+});
+```
+
+Logging is performed using `createServiceLogger`, `createPerformanceLogger`, and `createErrorLogger` to trace frame timing and errors.

--- a/docs/domains/rng.md
+++ b/docs/domains/rng.md
@@ -1,0 +1,14 @@
+# RNG Domain
+
+Provides deterministic random numbers with optional seeding.
+
+## Interface
+```ts
+export interface IRNGService {
+  random(): number;
+  randomInt(min: number, max: number, seed?: number): number;
+  dispose(): void;
+}
+```
+
+A seed can be passed to `randomInt` to reproduce values based on Bitcoin block data. Logging is minimal, but initialization and disposal events are recorded.

--- a/docs/domains/trait.md
+++ b/docs/domains/trait.md
@@ -1,0 +1,15 @@
+# Trait Domain
+
+Generates and mutates organism traits using deterministic randomness. Traits can be seeded from Bitcoin block data.
+
+## Interface
+```ts
+export interface ITraitService {
+  generateTraitsForOrganism(id: string, blockNonce?: number): OrganismTraits;
+  mutateTrait(traitType: string, currentValue: any): any;
+  applyTraitsToOrganism(organismId: string, traits: OrganismTraits): void;
+  dispose(): void;
+}
+```
+
+`generateTraitsForOrganism` creates a full trait map, optionally using a block nonce as a seed. `mutateTrait` produces a new trait value ensuring variation from the current value. Logging reports trait assignments and mutations.

--- a/docs/overview/Architecture.md
+++ b/docs/overview/Architecture.md
@@ -1,0 +1,17 @@
+# Domain‑Driven Architecture
+
+The project uses a strict domain structure. Each domain exposes a single service implementing an interface. All services follow the `static #instance` singleton pattern and provide a `dispose()` method for cleanup. Domains interact only via interfaces injected at initialization to maintain isolation.
+
+## Domain List
+- **Rendering** – Three.js scene management
+- **Animation** – Frame updates and easing functions
+- **Effect** – Visual particle effects
+- **Trait** – Organism trait definitions and mutations
+- **Physics** – Vector math and particle distribution
+- **Particle** – Lifecycle management of particles
+- **Formation** – Geometric pattern placement
+- **Group** – Clustering and management of particle groups
+- **RNG** – Seeded random number generation
+- **Bitcoin** – Access to blockchain data
+
+Scripts automate project scaffolding, pattern enforcement and compliance checks.

--- a/docs/overview/MVP.md
+++ b/docs/overview/MVP.md
@@ -1,0 +1,10 @@
+# MVP – Bitcoin‑Seeded Digital Organisms
+
+Protozoa generates and evolves digital organisms using Bitcoin Ordinals. Each organism is deterministically seeded from Bitcoin block data so that its traits are permanently tied to blockchain history. The system includes:
+
+- **Trait Generation** – Traits are derived from block header data and ordinals inscriptions.
+- **Physics Engine** – Custom physics governs particle behavior and group formations.
+- **Visualization** – Three.js renders organisms in real‑time with React integration.
+- **On‑chain Storage** – Organism state hashes are inscribed via the Ordinals protocol.
+
+The goal is to provide a reproducible simulation where every Bitcoin block can produce a unique organism lineage.

--- a/docs/overview/README.md
+++ b/docs/overview/README.md
@@ -1,0 +1,9 @@
+# Protozoa Documentation Overview
+
+This documentation suite provides a structured reference for building the **Protozoa** application. The project creates digital unicellular organisms seeded from Bitcoin block data and visualizes them in a 3D environment. Documentation is organized by domain so that both human developers and AI agents can easily locate relevant design details and implementation guidelines.
+
+## Contents
+- [MVP](MVP.md) – problem statement and high‑level goals
+- [Architecture](Architecture.md) – domain-driven design overview
+- [Domains](../domains/README.md) – index of domain specifications
+- [Automation Scripts](../scripts/README.md) – overview of PowerShell automation suite

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -1,0 +1,18 @@
+# Automation Scripts
+
+The `scripts` folder contains PowerShell utilities used to scaffold and maintain the project. Key scripts include:
+
+| Script | Purpose |
+|-------|---------|
+| `00-InitEnvironment.ps1` | install Node and dependencies |
+| `01-ScaffoldProjectStructure.ps1` | create domain folders and tests |
+| `02-GenerateDomainStubs.ps1` | generate TypeScript service stubs |
+| `03-MoveAndCleanCodebase.ps1` | move legacy files and fix imports |
+| `04-EnforceSingletonPatterns.ps1` | ensure all services use the singleton pattern |
+| `05-VerifyCompliance.ps1` | check file sizes and domain boundaries |
+| `06-DomainLint.ps1` | run ESLint per domain and detect cross imports |
+| `07-BuildAndTest.ps1` | compile and run tests |
+| `08-DeployToGitHub.ps1` | deployment automation |
+| `runAll.ps1` | orchestrates the entire sequence |
+
+Each script logs its progress to `automation.log` and exits with non‑zero status on failure.


### PR DESCRIPTION
## Summary
- add a `docs` folder containing an organized documentation suite derived from `build_design.md`
- update project README with a link to the docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850b2c3c0348324bb3f01741982ef7b